### PR TITLE
Reduce length and improve efficiency

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,8 +1,3 @@
-<IfModule mod_setenvif.c>
-  # Vary: Accept for all the requests to jpeg and png
-  SetEnvIf Request_URI "\.(jpe?g|png)$" REQUEST_image
-</IfModule>
-
 <IfModule mod_rewrite.c>
   RewriteEngine On
 
@@ -13,10 +8,11 @@
   RewriteCond %{DOCUMENT_ROOT}/$1.webp -f
 
   # Serve WebP image instead
-  RewriteRule (.+)\.(jpe?g|png)$ $1.webp [T=image/webp]
+  RewriteRule (.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=REQUEST_image]
 </IfModule>
 
 <IfModule mod_headers.c>
+  # Vary: Accept for all the requests to jpeg and png
   Header append Vary Accept env=REQUEST_image
 </IfModule>
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ This snippet detects if the browser [supports WebP](http://caniuse.com/#search=w
 ## Usage
 Place the following in your .htaccess file and jpg/png images will be replaced with WebP images if found in the same folder.
 ```apache
-<IfModule mod_setenvif.c>
-  # Vary: Accept for all the requests to jpeg and png
-  SetEnvIf Request_URI "\.(jpe?g|png)$" REQUEST_image
-</IfModule>
-
 <IfModule mod_rewrite.c>
   RewriteEngine On
 
@@ -19,10 +14,11 @@ Place the following in your .htaccess file and jpg/png images will be replaced w
   RewriteCond %{DOCUMENT_ROOT}/$1.webp -f
 
   # Serve WebP image instead
-  RewriteRule (.+)\.(jpe?g|png)$ $1.webp [T=image/webp]
+  RewriteRule (.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=REQUEST_image]
 </IfModule>
 
 <IfModule mod_headers.c>
+  # Vary: Accept for all the requests to jpeg and png
   Header append Vary Accept env=REQUEST_image
 </IfModule>
 


### PR DESCRIPTION
Just giving my thoughts on improving how the code works. Original `SetEnvIf `is not working OK with apache 2.4 at least, the breaking point seems to be in (jpe?g|png) when specifying optional "e" letter. Inside RewriteRule we can declare the enviromental variable in a simpler way reducing code length.